### PR TITLE
Adding creation and insertion time for lag and throughput calculation.

### DIFF
--- a/DB/files/start.sh
+++ b/DB/files/start.sh
@@ -1,8 +1,11 @@
 #!/bin/bash
 
 /entrypoint.sh mysqld &
-sleep 60
-mysql -h$HOSTNAME -uroot -ppasswd --execute="CREATE DATABASE reto1;"
-mysql -h$HOSTNAME -uroot -ppasswd reto1 --execute="CREATE TABLE reto1 (value VARCHAR(100) NOT NULL, insert_time TIMESTAMP NOT NULL);"
-
+until mysql -h$HOSTNAME -uroot -ppasswd --execute="CREATE DATABASE reto1;"
+do
+  echo "Creating database failed. Trying again in three seconds ..."
+  sleep 3
+done
+mysql -h$HOSTNAME -uroot -ppasswd reto1 --execute="CREATE TABLE reto1 (creation_time DATETIME(6), insert_time DATETIME(6) );"
+echo Done!!!!!
 wait %1

--- a/DB/start.sh
+++ b/DB/start.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-docker run --name reto1db -e MYSQL_ROOT_PASSWORD=passwd -p 3306:3306 -d reto1db
+docker run --name reto1db -e MYSQL_ROOT_PASSWORD=passwd -p 3306:3306 reto1db

--- a/load/files/tsung.xml
+++ b/load/files/tsung.xml
@@ -22,9 +22,18 @@
   <session name="http-example" probability="100" type="ts_http">
 
     <for from="1" to="10" incr="1" var="counter">
-      <request>
-        <http url="/" method="POST" version="1.1" contents="value=123123"></http>
+      <setdynvars sourcetype="eval" code="fun({Pid,DynVars})->
+          Now = os:timestamp(),
+          {_, _, Micro} = Now,
+          {{Year,Mon,Day},{Hour,Min,Sec}} = calendar:now_to_universal_time(Now),
+          io_lib:format('~4..0b-~2..0b-~2..0b ~2..0b:~2..0b:~2..0b.~6..0b', [Year,Mon,Day,Hour,Min,Sec,Micro])
+        end.">
+        <var name="nowts" />
+      </setdynvars>
+      <request subst="true">
+        <http url="/" method="POST" version="1.1" contents="value=%%_nowts%%"></http>
       </request>
+
     </for>
     
   </session>

--- a/server_node/files/dummy-web-server.js
+++ b/server_node/files/dummy-web-server.js
@@ -40,7 +40,7 @@ function process(pool, req, res) {
         			return;
       			}  
   
-      			connection.query("insert into reto1 values (?, now())", params.value, function(err, result) {
+      			connection.query("insert into reto1 values (?, current_timestamp(6))", params.value, function(err, result) {
         			connection.release();
   
         			if (err) {

--- a/server_python/files/dummy-web-server.py
+++ b/server_python/files/dummy-web-server.py
@@ -55,7 +55,7 @@ class S(BaseHTTPRequestHandler):
         global x
         global line_number
         postvars = self.parse_POST()
-        x.execute("""INSERT INTO reto1 VALUES (%s, now())""", (postvars.get("value")))
+        x.execute("""INSERT INTO reto1 VALUES (%s, current_timestamp(6) )""", (postvars.get("value")))
         line_number += 1
         if line_number == 20:
             mysql_conn.commit()


### PR DESCRIPTION
This change adds a timestamp with microseconds with the insertion and creation time.
It also changes the start up script of the database so that the creation of the database and the table are retried every 3 seconds (instead of waiting for 60). This helps a lot in my old Mac Mini, and it probably reduces the wait in faster computers.
